### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -34,13 +34,13 @@ jobs:
         id: new-version
         run: |
           NEW_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: Find old version
         id: old-version
         run: |
           git checkout ${{ github.event.pull_request.base.sha || github.event.before }}
           OLD_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$OLD_VERSION"
+          echo "version=$OLD_VERSION" >> $GITHUB_OUTPUT
 
   helm-will-release:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
           git log --exit-code $last_revision...${{ github.event.pull_request.base.sha }} charts/gitops-server
           unreleased_commits=$?
           if [[ $unreleased_commits == 1 ]]; then
-              echo "::set-output name=unreleased-commits::The last chart was last released in $last_revision and there have been other changes in the chart since"
+              echo "unreleased-commits=The last chart was last released in $last_revision and there have been other changes in the chart since" >> $GITHUB_OUTPUT
           fi
       - name: Let user know merging will cause a release
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
@@ -86,7 +86,7 @@ jobs:
         id: new_version
         run: |
           NEW_VERSION=$(yq e '.version' charts/gitops-server/Chart.yaml)
-          echo "::set-output name=version::$NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       - name: Generate new chart
         run: |
           URL=https://helm.gitops.weave.works

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,7 +104,7 @@ jobs:
       tag: ${{ steps.generate-tag.outputs.tag }}
     steps:
       - id: generate-tag
-        run: echo "::set-output name=tag::$(date -u +%s)-${{ github.sha }}"
+        run: echo "tag=$(date -u +%s)-${{ github.sha }}" >> $GITHUB_OUTPUT
 
   ci-build-gitops-image:
     name: CI Build Gitops Docker Image
@@ -195,7 +195,7 @@ jobs:
     - id: gitsha
       run: |
         gitsha=$(git rev-parse --short ${{ github.sha }})
-        echo "::set-output name=sha::$gitsha"
+        echo "sha=$gitsha" >> $GITHUB_OUTPUT
     - name: build
       run: |
         make gitops
@@ -239,7 +239,7 @@ jobs:
         id: package-version
         run: |
           GITOPS_VERSION=$(git describe)
-          echo "::set-output name=js-version::$GITOPS_VERSION"
+          echo "js-version=$GITOPS_VERSION" >> $GITHUB_OUTPUT
           jq '.version = "'$GITOPS_VERSION'" | .name = "@weaveworks/weave-gitops-main"' < dist/package.json > dist/package-new.json
           mv dist/package-new.json dist/package.json
           cp .npmrc dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
           GITHUB_EVENT_PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           version=$(echo $GITHUB_EVENT_PULL_REQUEST_HEAD_REF | cut -d'/' -f2)
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
       - name: Set tag
         run: |
           git config user.name weave-gitops-bot

--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -23,7 +23,7 @@ jobs:
           new_version="$(curl -s --request GET --url "https://api.github.com/repos/fluxcd/flux2/releases?per_page=1" | jq . | jq '.[0] | .tag_name' | jq -r | sed -e 's/v//')"
 
           if [[ "$old_version" != "$new_version" ]]; then
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
           fi
   upgrade-flux:
     needs:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
