### PR TITLE
fix: remove rbac Secrets from app rules

### DIFF
--- a/core/nsaccess/nsaccess.go
+++ b/core/nsaccess/nsaccess.go
@@ -18,7 +18,7 @@ import (
 var DefautltWegoAppRules = []rbacv1.PolicyRule{
 	{
 		APIGroups: []string{""},
-		Resources: []string{"secrets", "pods", "events"},
+		Resources: []string{"pods", "events"},
 		Verbs:     []string{"get", "list"},
 	},
 	{


### PR DESCRIPTION
Be able to watch flux resources in UI without having rights to read secrets in k8s.

<!--
Use # to add the issue this pull request is related to.
nb: This is the Github issue number, not a Zenhub link.
Do not use any punctuation or bullet points.
eg:
Closes #1234
Fixes #5678
-->
Closes

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why was this change made?**


<!--
Explain to your reviewers the key implementation points, including why you made
certain choices in favour of others. Highlight key areas of the code which need
extra attention, and also indicate which parts are less relevant (eg renaming,
refactoring, etc
-->
**How was this change implemented?**


<!--
How have you verified this change/product value? Tested locally?
Added integration/acceptance test(s)?
Unit tests are required.
-->
**How did you validate the change?**


<!--
Is it notable for release? e.g. schema updates, configuration or data migration
required? If so, please mention it.
-->
**Release notes**


<!-- Are there any documentation updates that should be made for these changes? -->
**Documentation Changes**
